### PR TITLE
Fix "TS2304: Cannot find name 'ToastType'." error in TS definitions + make message optional when updating

### DIFF
--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ToastType, ToastContainerProps as ReactToastContainerProps} from "react-toastify";
+import {ToastContainerProps as ReactToastContainerProps} from "react-toastify";
 import {ComponentClass, SFC} from "react";
 
 export interface ToastBaseOptions {
@@ -20,7 +20,7 @@ export interface ToastBaseOptions {
    * Set the toast type.
    * `One of: 'info', 'success', 'warning', 'error', 'default'`
    */
-  type?: ToastType;
+  type?: 'info' | 'success' | 'warning' | 'error' | 'default';
 
   /**
    * Pause the timer when the mouse hover the toast.

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -152,7 +152,7 @@ export interface DismissActionPayload {
  * Update action options
  */
 export interface UpdateActionOptions extends ToastBaseOptions {
-  message: any;
+  message?: any;
 }
 
 /**


### PR DESCRIPTION
<img width="641" alt="screen shot 2018-11-13 at 11 27 26" src="https://user-images.githubusercontent.com/189707/48410776-8d9e9d00-e737-11e8-82a1-5dcb3a4b9662.png">

The current Typescript definitions throw a TS2304 error, because the `ToastType` import being used here (imported from the react-toastify package) is an interface, not a type definition - https://github.com/fkhadra/react-toastify/blob/master/index.d.ts#L299.

The type definition that needs to be matched against is actually `TypeOptions` - https://github.com/fkhadra/react-toastify/blob/master/index.d.ts#L70 - however this is not exported.

Seeing as a load of other types are being manually defined in the react-toastify-redux definitions file (eg. `pauseOnHover`, `hideProgressBar`) I think it makes sense to just manually define the types locally, until the core package exports the necessary types.

I've also changed the message option to be optional on the `update()` method definition; it's not required in the core package, as you may only want to update another option such as type.